### PR TITLE
[Soccer] Report delete fix

### DIFF
--- a/soccer/module.py
+++ b/soccer/module.py
@@ -261,10 +261,8 @@ class Soccer(
             self.embed_cache.pop(message.id)
             return
 
-        messages = await message.channel.history(
-            after=message, limit=3, oldest_first=True
-        )
-        for report in messages:
+        messages = message.channel.history(after=message, limit=3, oldest_first=True)
+        async for report in messages:
             if not report.author.bot:
                 continue
             if len(report.embeds) != 1 or not isinstance(


### PR DESCRIPTION
```CRITICAL: Uncaught error bubbled-up.
Traceback: 
object async_generator can't be used in 'await' expression
  File "/root/.local/lib/python3.12/site-packages/discord/client.py", line 441, in _run_event
    await coro(*args, **kwargs)

  File "/strawberry-py/modules/games/soccer/module.py", line 193, in on_message
    await self._check_message(message)

  File "/strawberry-py/modules/games/soccer/module.py", line 251, in _check_message
    await self._delete_report(message)

  File "/strawberry-py/modules/games/soccer/module.py", line 264, in _delete_report
    messages = await message.channel.history(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^```